### PR TITLE
Fix DB config handling and cleanup logs

### DIFF
--- a/build/routes/auth.js
+++ b/build/routes/auth.js
@@ -8,7 +8,6 @@ const router = (0, express_1.Router)();
 exports.authRouter = router;
 router.post('/login', async (req, res) => {
     const { email, password } = req.body;
-    console.log('login', email, password);
     if (!email || !password) {
         res.sendStatus(400);
         return;
@@ -24,10 +23,8 @@ router.post('/login', async (req, res) => {
         return;
     }
     const token = (0, jwt_1.sign)({ userId: user.id }, 3600);
-    console.log('token', token);
     res.cookie('token', token, { httpOnly: true });
     res.json({ id: user.id, email: user.email });
-    console.log('respose status', res.statusCode);
 });
 router.post('/logout', (_req, res) => {
     res.clearCookie('token');

--- a/build/routes/notes.js
+++ b/build/routes/notes.js
@@ -17,12 +17,10 @@ router.get('/:id', authorization_1.authorizeNote, (req, res) => {
 });
 router.post('/', authentication_1.authenticateUser, async (req, res) => {
     const { title, content } = req.body;
-    console.log('createNote', req.user.id, title, content);
     if (!title || !content) {
         res.sendStatus(400);
         return;
     }
-    console.log('createNote', req.user.id, title, content);
     const note = await (0, note_1.createNote)(req.user.id, title, content);
     res.status(201).json(note);
 });

--- a/build/routes/users.js
+++ b/build/routes/users.js
@@ -25,7 +25,6 @@ router.get('/me', authentication_1.authenticateUser, (req, res) => {
 });
 router.post('/join', async (req, res) => {
     const { email, password } = req.body;
-    console.log('join', email, password);
     if (!email || !password) {
         res.sendStatus(400);
         return;

--- a/build/settings.js
+++ b/build/settings.js
@@ -7,9 +7,6 @@ exports.JWT_SECRET = exports.PORT = exports.DB_USER = exports.DB_PORT = exports.
 // src/settings.ts
 const dotenv_1 = __importDefault(require("dotenv"));
 dotenv_1.default.config();
-console.log('NODE_ENV from settings:', process.env.NODE_ENV); // Added for debugging
-console.log('DEV_DB_PASSWORD length from settings:', process.env.DEV_DB_PASSWORD?.length); // Added for debugging
-console.log('DEV_DB_USER from settings:', process.env.DEV_DB_USER); // Added for debugging
 // Server configuration
 const NODE_ENV = process.env.NODE_ENV;
 let PORT;
@@ -27,13 +24,12 @@ if (NODE_ENV === 'production') {
     exports.DB_NAME = DB_NAME = process.env.PROD_DB_NAME;
 }
 else {
-    // Defaults to development settings if NODE_ENV is not 'production'
     exports.PORT = PORT = process.env.DEV_PORT || 3031;
-    exports.DB_HOST = DB_HOST = process.env.DEV_DB_HOST;
+    exports.DB_HOST = DB_HOST = process.env.DEV_DB_HOST || 'localhost';
     exports.DB_PORT = DB_PORT = parseInt(process.env.DEV_DB_PORT || '3306', 10);
-    exports.DB_USER = DB_USER = process.env.DEV_DB_USER;
-    exports.DB_PASSWORD = DB_PASSWORD = process.env.DEV_DB_PASSWORD;
-    exports.DB_NAME = DB_NAME = process.env.DEV_DB_NAME;
+    exports.DB_USER = DB_USER = process.env.DEV_DB_USER || 'prgms';
+    exports.DB_PASSWORD = DB_PASSWORD = process.env.DEV_DB_PASSWORD || 'prgms';
+    exports.DB_NAME = DB_NAME = process.env.DEV_DB_NAME || 'prgms_notes';
 }
 // Environment variables and settings
 exports.JWT_SECRET = process.env.JWT_SECRET;

--- a/build/utils/mysql.js
+++ b/build/utils/mysql.js
@@ -11,37 +11,30 @@ exports.pool = void 0;
 // 역할: DB SQL 쿼리를 위한 연결 Pool 제공
 const promise_1 = __importDefault(require("mysql2/promise"));
 const settings_1 = require("../settings");
-// Added for debugging
-console.log('[mysql.ts] Attempting to create pool with:', {
-    host: settings_1.DB_HOST,
-    port: settings_1.DB_PORT,
-    user: settings_1.DB_USER,
-    password_length: settings_1.DB_PASSWORD?.length, // Log password length for security
-    database: settings_1.DB_NAME,
-});
-exports.pool = promise_1.default.createPool({
-    host: settings_1.DB_HOST,
-    port: settings_1.DB_PORT,
-    user: settings_1.DB_USER,
-    password: settings_1.DB_PASSWORD,
-    database: settings_1.DB_NAME,
-    waitForConnections: true,
-    connectionLimit: 10, // Adjust as needed
-    queueLimit: 0,
-    dateStrings: true, // To ensure dates are returned as strings
-});
-// Optional: Test the connection
-async function testConnection() {
-    try {
-        const connection = await exports.pool.getConnection();
-        console.log('Successfully connected to the database.');
-        connection.release();
-    }
-    catch (error) {
-        console.error('Error connecting to the database:', error);
-        // Exit the process if the database connection fails during startup in a real scenario
-        // process.exit(1);
-    }
+/**
+ * Creates a MySQL pool when database credentials are provided. When the
+ * credentials are missing, a mock pool is exported that rejects all queries.
+ */
+function createMockPool() {
+    return {
+        async query() {
+            throw new Error('Database is not configured');
+        },
+        async getConnection() {
+            throw new Error('Database is not configured');
+        },
+    };
 }
-// Call testConnection if you want to verify on app startup
-// testConnection();
+exports.pool = settings_1.DB_HOST && settings_1.DB_USER && settings_1.DB_PASSWORD && settings_1.DB_NAME
+    ? promise_1.default.createPool({
+        host: settings_1.DB_HOST,
+        port: settings_1.DB_PORT,
+        user: settings_1.DB_USER,
+        password: settings_1.DB_PASSWORD,
+        database: settings_1.DB_NAME,
+        waitForConnections: true,
+        connectionLimit: 10,
+        queueLimit: 0,
+        dateStrings: true,
+    })
+    : createMockPool();

--- a/env.copy
+++ b/env.copy
@@ -14,8 +14,8 @@ PROD_DB_USER=prgms
 PROD_DB_PASSWORD=prgms 
 PROD_DB_NAME=prgms_notes
 
-DEV_DB_HOST=http://localhost
-DEV_DB_PORT=30036 
+DEV_DB_HOST=localhost
+DEV_DB_PORT=3306
 DEV_DB_USER=prgms
 DEV_DB_PASSWORD=prgms 
 DEV_DB_NAME=prgms_notes

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -6,7 +6,6 @@ const router = Router()
 
 router.post('/login', async (req, res) => {
   const { email, password } = req.body
-  console.log('login', email, password)
   if (!email || !password) {
     res.sendStatus(400)
     return
@@ -22,10 +21,8 @@ router.post('/login', async (req, res) => {
     return
   }
   const token = sign({ userId: user.id }, 3600)
-  console.log('token', token)
   res.cookie('token', token, { httpOnly: true })
   res.json({ id: user.id, email: user.email })
-  console.log('respose status', res.statusCode)
 })
 
 router.post('/logout', (_req, res) => {

--- a/src/routes/notes.ts
+++ b/src/routes/notes.ts
@@ -23,12 +23,10 @@ router.get('/:id', authorizeNote, (req, res) => {
 
 router.post('/', authenticateUser, async (req, res) => {
   const { title, content } = req.body
-  console.log('createNote', req.user!.id, title, content)
   if (!title || !content) {
     res.sendStatus(400)
     return
   }
-  console.log('createNote', req.user!.id, title, content)
   const note = await createNote(req.user!.id, title, content)
   res.status(201).json(note)
 })

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -25,7 +25,6 @@ router.get('/me', authenticateUser, (req, res) => {
 
 router.post('/join', async (req, res) => {
   const { email, password } = req.body
-  console.log('join', email, password)
   if (!email || !password) {
     res.sendStatus(400)
     return

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -2,13 +2,6 @@
 import dotenv from 'dotenv'
 dotenv.config()
 
-console.log('NODE_ENV from settings:', process.env.NODE_ENV) // Added for debugging
-console.log(
-  'DEV_DB_PASSWORD length from settings:',
-  process.env.DEV_DB_PASSWORD?.length,
-) // Added for debugging
-console.log('DEV_DB_USER from settings:', process.env.DEV_DB_USER) // Added for debugging
-
 // Server configuration
 const NODE_ENV = process.env.NODE_ENV
 
@@ -27,13 +20,12 @@ if (NODE_ENV === 'production') {
   DB_PASSWORD = process.env.PROD_DB_PASSWORD
   DB_NAME = process.env.PROD_DB_NAME
 } else {
-  // Defaults to development settings if NODE_ENV is not 'production'
   PORT = process.env.DEV_PORT || 3031
-  DB_HOST = process.env.DEV_DB_HOST
+  DB_HOST = process.env.DEV_DB_HOST || 'localhost'
   DB_PORT = parseInt(process.env.DEV_DB_PORT || '3306', 10)
-  DB_USER = process.env.DEV_DB_USER
-  DB_PASSWORD = process.env.DEV_DB_PASSWORD
-  DB_NAME = process.env.DEV_DB_NAME
+  DB_USER = process.env.DEV_DB_USER || 'prgms'
+  DB_PASSWORD = process.env.DEV_DB_PASSWORD || 'prgms'
+  DB_NAME = process.env.DEV_DB_NAME || 'prgms_notes'
 }
 
 export { DB_HOST, DB_NAME, DB_PASSWORD, DB_PORT, DB_USER, PORT }

--- a/src/utils/mysql.ts
+++ b/src/utils/mysql.ts
@@ -8,39 +8,33 @@
 import mysql from 'mysql2/promise'
 import { DB_HOST, DB_NAME, DB_PASSWORD, DB_PORT, DB_USER } from '../settings'
 
-// Added for debugging
-console.log('[mysql.ts] Attempting to create pool with:', {
-  host: DB_HOST,
-  port: DB_PORT,
-  user: DB_USER,
-  password_length: DB_PASSWORD?.length, // Log password length for security
-  database: DB_NAME,
-})
+/**
+ * Creates a MySQL pool when database credentials are provided. When the
+ * credentials are missing, a mock pool is exported that rejects all queries.
+ */
 
-export const pool = mysql.createPool({
-  host: DB_HOST,
-  port: DB_PORT,
-  user: DB_USER,
-  password: DB_PASSWORD,
-  database: DB_NAME,
-  waitForConnections: true,
-  connectionLimit: 10, // Adjust as needed
-  queueLimit: 0,
-  dateStrings: true, // To ensure dates are returned as strings
-})
-
-// Optional: Test the connection
-async function testConnection() {
-  try {
-    const connection = await pool.getConnection()
-    console.log('Successfully connected to the database.')
-    connection.release()
-  } catch (error) {
-    console.error('Error connecting to the database:', error)
-    // Exit the process if the database connection fails during startup in a real scenario
-    // process.exit(1);
-  }
+function createMockPool() {
+  return {
+    async query() {
+      throw new Error('Database is not configured')
+    },
+    async getConnection() {
+      throw new Error('Database is not configured')
+    },
+  } as unknown as mysql.Pool
 }
 
-// Call testConnection if you want to verify on app startup
-// testConnection();
+export const pool: mysql.Pool =
+  DB_HOST && DB_USER && DB_PASSWORD && DB_NAME
+    ? mysql.createPool({
+        host: DB_HOST,
+        port: DB_PORT,
+        user: DB_USER,
+        password: DB_PASSWORD,
+        database: DB_NAME,
+        waitForConnections: true,
+        connectionLimit: 10,
+        queueLimit: 0,
+        dateStrings: true,
+      })
+    : createMockPool()


### PR DESCRIPTION
## Summary
- provide sane defaults for development DB settings
- handle missing DB configuration gracefully with a mock pool
- clean up debugging logs in routes
- update env copy defaults

## Testing
- `npm run build`
- `npm start`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6842860716a0832eb0c8737a880a951b